### PR TITLE
Ignore end_of_stream error when fetching a http page

### DIFF
--- a/src/fetch_http_page.h
+++ b/src/fetch_http_page.h
@@ -23,6 +23,13 @@ fetch_http_page( asio::io_service& ios
 
     // Send the HTTP request to the remote host
     http::async_write(con, req, yield[ec]);
+
+    // Ignore end_of_stream error, there may still be data in the receive
+    // buffer we can read.
+    if (ec == http::error::end_of_stream) {
+        ec = sys::error_code();
+    }
+
     if (ec) return or_throw(yield, ec, move(res));
 
     beast::flat_buffer buffer;


### PR DESCRIPTION
fixes https://github.com/equalitie/ouinet/issues/15
https://github.com/boostorg/beast/issues/1023
closes #15