### PR TITLE
libi2pd and libi2pd_client android build

### DIFF
--- a/android/i2pd/jni/Android.mk
+++ b/android/i2pd/jni/Android.mk
@@ -1,0 +1,21 @@
+LOCAL_PATH := $(call my-dir)
+
+# export BOOST_PATH, OPENSSL_PATH and IFADDRS_PATH before
+# build libi2pd
+include $(CLEAR_VARS)
+LOCAL_MODULE := libi2pd
+LOCAL_CPP_FEATURES := rtti exceptions
+LOCAL_C_INCLUDES += $(IFADDRS_PATH) $(LIB_SRC_PATH) $(BOOST_PATH)/include $(OPENSSL_PATH)/include
+LOCAL_SRC_FILES := $(IFADDRS_PATH)/ifaddrs.c \
+	$(wildcard $(LIB_SRC_PATH)/*.cpp)
+include $(BUILD_STATIC_LIBRARY)
+
+# build libi2pd_client
+include $(CLEAR_VARS)
+LOCAL_MODULE := libi2pd_client
+LOCAL_CPP_FEATURES := rtti exceptions
+LOCAL_C_INCLUDES += $(LIB_SRC_PATH) $(LIB_CLIENT_SRC_PATH) $(BOOST_PATH)/include $(OPENSSL_PATH)/include
+LOCAL_SRC_FILES := $(wildcard $(LIB_CLIENT_SRC_PATH)/*.cpp)
+include $(BUILD_STATIC_LIBRARY)
+
+

--- a/android/i2pd/jni/Application.mk
+++ b/android/i2pd/jni/Application.mk
@@ -1,0 +1,25 @@
+#APP_ABI := all
+#APP_ABI := armeabi-v7a x86
+#APP_ABI := x86
+#APP_ABI := x86_64
+APP_ABI := armeabi-v7a
+#can be android-3 but will fail for x86 since arch-x86 is not present at ndkroot/platforms/android-3/ . libz is taken from there.
+APP_PLATFORM := android-14
+
+NDK_TOOLCHAIN_VERSION := clang
+APP_STL := c++_static
+
+# Enable c++11 extensions in source code
+APP_CPPFLAGS += -std=c++11 -fvisibility=default -fPIE
+
+APP_CPPFLAGS += -DANDROID_BINARY -DANDROID -D__ANDROID__ 
+APP_LDFLAGS += -rdynamic -fPIE -pie
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+APP_CPPFLAGS += -DANDROID_ARM7A
+endif
+
+# don't change me
+I2PD_SRC_PATH = $(PWD)/../../src/ouiservice/i2p/i2pd
+
+LIB_SRC_PATH = $(I2PD_SRC_PATH)/libi2pd
+LIB_CLIENT_SRC_PATH = $(I2PD_SRC_PATH)/libi2pd_client


### PR DESCRIPTION
specify variabled BOOST_PATH, OPENSSL_PATH and IFADDRS_PATH
then run ndk-build from ouinet/android/i2pd