### PR TITLE
Configurable endpoints in Ouinet.java

### DIFF
--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Config.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Config.java
@@ -46,6 +46,8 @@ public class Config implements Parcelable {
         private boolean cachePrivate = false;
         private String cacheStaticPath;
         private String cacheStaticContentPath;
+        private String listenOnTcp;
+        private String frontEndEp;
         private boolean disableOriginAccess   = false;
         private boolean disableProxyAccess    = false;
         private boolean disableInjectorAccess = false;
@@ -92,6 +94,14 @@ public class Config implements Parcelable {
         }
         public ConfigBuilder setCacheStaticContentPath(String cacheStaticContentPath){
             this.cacheStaticContentPath = cacheStaticContentPath;
+            return this;
+        }
+        public ConfigBuilder setListenOnTcp(String listenOnTcp){
+            this.listenOnTcp = listenOnTcp;
+            return this;
+        }
+        public ConfigBuilder setFrontEndEp(String frontEndEp){
+            this.frontEndEp = frontEndEp;
             return this;
         }
         public ConfigBuilder setDisableOriginAccess(boolean disableOriginAccess){
@@ -250,6 +260,8 @@ public class Config implements Parcelable {
                     cachePrivate,
                     cacheStaticPath,
                     cacheStaticContentPath,
+                    listenOnTcp,
+                    frontEndEp,
                     disableOriginAccess,
                     disableProxyAccess,
                     disableInjectorAccess,
@@ -269,6 +281,8 @@ public class Config implements Parcelable {
     private boolean cachePrivate;
     private String cacheStaticPath;
     private String cacheStaticContentPath;
+    private String listenOnTcp;
+    private String frontEndEp;
     private boolean disableOriginAccess;
     private boolean disableProxyAccess;
     private boolean disableInjectorAccess;
@@ -286,6 +300,8 @@ public class Config implements Parcelable {
                   boolean cachePrivate,
                   String cacheStaticPath,
                   String cacheStaticContentPath,
+                  String listenOnTcp,
+                  String frontEndEp,
                   boolean disableOriginAccess,
                   boolean disableProxyAccess,
                   boolean disableInjectorAccess,
@@ -302,6 +318,8 @@ public class Config implements Parcelable {
         this.cachePrivate = cachePrivate;
         this.cacheStaticPath = cacheStaticPath;
         this.cacheStaticContentPath = cacheStaticContentPath;
+        this.listenOnTcp = listenOnTcp;
+        this.frontEndEp = frontEndEp;
         this.disableOriginAccess = disableOriginAccess;
         this.disableProxyAccess = disableProxyAccess;
         this.disableInjectorAccess = disableInjectorAccess;
@@ -340,6 +358,12 @@ public class Config implements Parcelable {
     }
     public String getCacheStaticContentPath() {
         return cacheStaticContentPath;
+    }
+    public String getListenOnTcp() {
+        return listenOnTcp;
+    }
+    public String getFrontEndEp() {
+        return frontEndEp;
     }
     public boolean getDisableOriginAccess() {
         return disableOriginAccess;
@@ -386,6 +410,8 @@ public class Config implements Parcelable {
         out.writeInt(cachePrivate ? 1 : 0);
         out.writeString(cacheStaticPath);
         out.writeString(cacheStaticContentPath);
+        out.writeString(listenOnTcp);
+        out.writeString(frontEndEp);
         out.writeInt(disableOriginAccess ? 1 : 0);
         out.writeInt(disableProxyAccess ? 1 : 0);
         out.writeInt(disableInjectorAccess ? 1 : 0);
@@ -405,6 +431,8 @@ public class Config implements Parcelable {
         cachePrivate = in.readInt() != 0;
         cacheStaticPath = in.readString();
         cacheStaticContentPath = in.readString();
+        listenOnTcp= in.readString();
+        frontEndEp = in.readString();
 
         disableOriginAccess   = in.readInt() != 0;
         disableProxyAccess    = in.readInt() != 0;

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -114,9 +114,10 @@ public class Ouinet {
         args.add("--repo=" + config.getOuinetDirectory());
 
         // If default client endpoints clash with other ports,
-        // uncomment these and change `http(s).proxyPort` above to match.
-        //args.add("--listen-on-tcp=127.0.0.1:8177");
-        //args.add("--front-end-ep=127.0.0.1:8178");
+        // use setListenOnTcp or setFrontEndEp in the Config builder
+        // and change `http(s).proxyPort` to match.
+        maybeAdd(args, "--listen-on-tcp",          config.getListenOnTcp());
+        maybeAdd(args, "--front-end-ep",           config.getFrontEndEp());
 
         maybeAdd(args, "--injector-credentials",   config.getInjectorCredentials());
         maybeAdd(args, "--cache-http-public-key",  config.getCacheHttpPubKey());

--- a/android/ouinet/src/test/java/ie/equalit/ouinet/ConfigTest.java
+++ b/android/ouinet/src/test/java/ie/equalit/ouinet/ConfigTest.java
@@ -38,6 +38,8 @@ public class ConfigTest {
     private static String CACHE_TYPE = "bep5-http";
     private static String CACHE_STATIC_PATH = "static-cache";
     private static String CACHE_STATIC_CONTENT_PATH = "static-cache/.ouinet";
+    private static String LISTEN_ON_TCP = "0.0.0.0:8077";
+    private static String FRONT_END_EP = "0.0.0.0:8078";
 
     @Mock
     private Context mockContext;
@@ -77,6 +79,8 @@ public class ConfigTest {
                 .setCacheType(CACHE_TYPE)
                 .setCacheStaticPath(cacheStaticPath)
                 .setCacheStaticContentPath(cacheStaticContentPath)
+                .setListenOnTcp(LISTEN_ON_TCP)
+                .setFrontEndEp(FRONT_END_EP)
                 .build();
 
         assertThat(config.getOuinetDirectory(), is(ouinetDir));
@@ -86,6 +90,9 @@ public class ConfigTest {
         assertThat(config.getCacheType(), is(CACHE_TYPE));
         assertThat(config.getCacheStaticPath(), is(cacheStaticPath));
         assertThat(config.getCacheStaticContentPath(), is(cacheStaticContentPath));
+
+        assertThat(config.getListenOnTcp(), is(LISTEN_ON_TCP));
+        assertThat(config.getFrontEndEp(), is(FRONT_END_EP));
 
         assertThat(config.getTlsCaCertStorePath(), is(tlsCaCertPath));
         assertThat(contentOf(new File(config.getTlsCaCertStorePath())), is(TLS_CA_CERT));


### PR DESCRIPTION
Hi @ivilata, this is the branch that exposes `listen-on-tcp` and `front-end-ep` options in `Ouinet.java`

For the testing I've added some assertions to `ConfigTest` and also did some manual testing using the [sample application](https://github.com/mhqz/app1/commit/d1c9dd6474f77869728b45a7e54360d0bdb79680):

I've changed the code as follows:
```java
Config config = new Config.ConfigBuilder(this)
         // ...
        .setListenOnTcp("127.0.0.1:8888")
        .setFrontEndEp("127.0.0.1:5555")
```

```java
Proxy ouinetService= new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8888));
```
Then I got this in the logs and the requests were also forwarded to Ouinet  in port 8888.
```
    [INFO] Client listening to browser requests on TCP:127.0.0.1:8888
    [INFO] Client listening to frontend on TCP:127.0.0.1:5555
    [INFO] Serving front end on 127.0.0.1:5555
```
 
Please let me know if you have any questions or comments :slightly_smiling_face: 
