### PR TITLE
Omni aar

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,8 +764,9 @@ and that `<PROJECT DIR>` is your app's project directory.
 #### Option A: Get Ouinet from Maven Central
 
 Select the Ouinet version according to your app's ABI (we officially support
-`ouinet-armeabi-v7a` and `ouinet-arm64-v8a`), and also add Relinker as a
-dependency in `<PROJECT DIR>/app/build.gradle`:
+`ouinet-armeabi-v7a`, `ouinet-arm64-v8a` and `omni` that includes all the
+supported ABIs plus `x86_64`), and also add Relinker as adependency in
+`<PROJECT DIR>/app/build.gradle`:
 
 ```groovy
 dependencies {

--- a/android/ouinet/build.gradle
+++ b/android/ouinet/build.gradle
@@ -19,8 +19,13 @@ android {
                 targets "native-lib"
             }
         }
+
         ndk {
+          if (android_abi == "omni") {
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+          } else {
             abiFilters "$android_abi"
+          }
         }
     }
     buildTypes {

--- a/android/ouinet/build.gradle
+++ b/android/ouinet/build.gradle
@@ -19,7 +19,6 @@ android {
                 targets "native-lib"
             }
         }
-
         ndk {
           if (android_abi == "omni") {
             abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'

--- a/doc/android-sdk-versions.md
+++ b/doc/android-sdk-versions.md
@@ -139,3 +139,8 @@ instead.
 Since support for 64-bit architectures was added in Android SDK/API 21, 64-bit
 builds raise the minimum SDK version to 21.  `build-android.sh` takes care of
 setting the appropriate value of `OUINET_MIN_API` in this case.
+
+The same will happen for builds with targets compiled for different
+architectures in the same AAR, like `omni` that includes `armeabi-v7a`,
+`arm64-v8a` and `x86_64`). In this case, `build-android.sh` will adjust
+`OUINET_MIN_API` to 21 in order to keep compatibility with 64-bit libs.

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -26,6 +26,8 @@ elif [ "$ABI" = "x86" ]; then
     OUINET_MIN_API=16
 elif [ "$ABI" = "x86_64" ]; then
     OUINET_MIN_API=21
+elif [ "$ABI" = "omni" ]; then
+    OUINET_MIN_API=21
 else
     >&2 echo "Unsupported ABI: '$ABI', valid values are armeabi-v7a, arm64-v8a, x86, x86_64."
     exit 1


### PR DESCRIPTION
Hi @ivilata, this PR applies some minor modifications to the build scripts of Ouinet in order to have a new AAR target named `omni` that contains libraries for `armeabi-v7a`, `arm64-v8a` and `x86_64`.

I've also added some notes about this new target to `doc/android-sdk-versions.md` and `README.md`.

Please let me know if you have any questions or comments :)
