### PR TITLE
Fix ouinet stop

### DIFF
--- a/android/ouinet/src/main/cpp/native-lib.cpp
+++ b/android/ouinet/src/main/cpp/native-lib.cpp
@@ -175,9 +175,15 @@ Java_ie_equalit_ouinet_Ouinet_nStopClient(
         JNIEnv *env,
         jobject /* this */)
 {
-    g_ios.post([] { if (g_client) g_client->stop(); });
-    g_client_thread.join();
-    g_client_thread = thread();
+    try {
+      g_ios.post([] { if (g_client) g_client->stop(); });
+      g_client_thread.join();
+      g_client_thread = thread();
+    } catch (const std::exception &e) {
+      debug("Failed to stop Ouinet client:");
+      debug("%s", e.what());
+      return;
+    }
 }
 
 extern "C"

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -195,6 +195,8 @@ public class Ouinet {
     // ouinet/client will have all of it's resources freed. It should be called
     // no later than in Activity.onDestroy()
     public synchronized void stop() {
+        if (getState() == RunningState.Stopped) return;
+
         nStopClient();
         if (lock != null && lock.isHeld()) {
             lock.release();

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -196,7 +196,7 @@ public class Ouinet {
     // no later than in Activity.onDestroy()
     public synchronized void stop() {
         nStopClient();
-        if (lock != null) {
+        if (lock != null && lock.isHeld()) {
             lock.release();
         }
         if (wifiChangeReceiver != null) {


### PR DESCRIPTION
This is the patch that fixes the error `thread::join failed: Invalid argument`. The fix is quite simple and now that I'm able to validate it with the instrumented tests in the example applications I think we can proceed to release it as `0.21.3`.

Please let me know if you have any questions or comments.