### PR TITLE
Configurable max cache age to keep, DNS over HTTPS and uncacheable domain in Ouinet.java

### DIFF
--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Config.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Config.java
@@ -51,6 +51,9 @@ public class Config implements Parcelable {
         private String cacheStaticContentPath;
         private String listenOnTcp;
         private String frontEndEp;
+        private String maxCachedAge;
+        private String localDomain;
+        private String originDohBase;
         private boolean disableOriginAccess   = false;
         private boolean disableProxyAccess    = false;
         private boolean disableInjectorAccess = false;
@@ -122,6 +125,18 @@ public class Config implements Parcelable {
         }
         public ConfigBuilder setFrontEndEp(String frontEndEp){
             this.frontEndEp = frontEndEp;
+            return this;
+        }
+        public ConfigBuilder setMaxCachedAge(String maxCachedAge){
+            this.maxCachedAge = maxCachedAge;
+            return this;
+        }
+        public ConfigBuilder setLocalDomain(String localDomain){
+            this.localDomain = localDomain;
+            return this;
+        }
+        public ConfigBuilder setOriginDohBase(String originDohBase){
+            this.originDohBase = originDohBase;
             return this;
         }
         public ConfigBuilder setDisableOriginAccess(boolean disableOriginAccess){
@@ -283,6 +298,9 @@ public class Config implements Parcelable {
                     cacheStaticContentPath,
                     listenOnTcp,
                     frontEndEp,
+                    maxCachedAge,
+                    localDomain,
+                    originDohBase,
                     disableOriginAccess,
                     disableProxyAccess,
                     disableInjectorAccess,
@@ -305,6 +323,9 @@ public class Config implements Parcelable {
     private String cacheStaticContentPath;
     private String listenOnTcp;
     private String frontEndEp;
+    private String maxCachedAge;
+    private String localDomain;
+    private String originDohBase;
     private boolean disableOriginAccess;
     private boolean disableProxyAccess;
     private boolean disableInjectorAccess;
@@ -325,6 +346,9 @@ public class Config implements Parcelable {
                   String cacheStaticContentPath,
                   String listenOnTcp,
                   String frontEndEp,
+                  String maxCachedAge,
+                  String localDomain,
+                  String originDohBase,
                   boolean disableOriginAccess,
                   boolean disableProxyAccess,
                   boolean disableInjectorAccess,
@@ -344,6 +368,9 @@ public class Config implements Parcelable {
         this.cacheStaticContentPath = cacheStaticContentPath;
         this.listenOnTcp = listenOnTcp;
         this.frontEndEp = frontEndEp;
+        this.maxCachedAge = maxCachedAge;
+        this.localDomain = localDomain;
+        this.originDohBase = originDohBase;
         this.disableOriginAccess = disableOriginAccess;
         this.disableProxyAccess = disableProxyAccess;
         this.disableInjectorAccess = disableInjectorAccess;
@@ -391,6 +418,15 @@ public class Config implements Parcelable {
     }
     public String getFrontEndEp() {
         return frontEndEp;
+    }
+    public String getMaxCachedAge() {
+        return maxCachedAge;
+    }
+    public String getLocalDomain() {
+        return localDomain;
+    }
+    public String getOriginDohBase() {
+        return originDohBase;
     }
     public boolean getDisableOriginAccess() {
         return disableOriginAccess;
@@ -440,6 +476,9 @@ public class Config implements Parcelable {
         out.writeString(cacheStaticContentPath);
         out.writeString(listenOnTcp);
         out.writeString(frontEndEp);
+        out.writeString(maxCachedAge);
+        out.writeString(localDomain);
+        out.writeString(originDohBase);
         out.writeInt(disableOriginAccess ? 1 : 0);
         out.writeInt(disableProxyAccess ? 1 : 0);
         out.writeInt(disableInjectorAccess ? 1 : 0);
@@ -471,6 +510,9 @@ public class Config implements Parcelable {
         cacheStaticContentPath = in.readString();
         listenOnTcp= in.readString();
         frontEndEp = in.readString();
+        maxCachedAge = in.readString();
+        localDomain = in.readString();
+        originDohBase = in.readString();
 
         disableOriginAccess   = in.readInt() != 0;
         disableProxyAccess    = in.readInt() != 0;

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -120,6 +120,9 @@ public class Ouinet {
         // and change `http(s).proxyPort` to match.
         maybeAdd(args, "--listen-on-tcp",          config.getListenOnTcp());
         maybeAdd(args, "--front-end-ep",           config.getFrontEndEp());
+        maybeAdd(args, "--max-cached-age",         config.getMaxCachedAge());
+        maybeAdd(args, "--local-domain",           config.getLocalDomain());
+        maybeAdd(args, "--origin-doh-base",        config.getOriginDohBase());
 
         maybeAdd(args, "--injector-credentials",   config.getInjectorCredentials());
         maybeAdd(args, "--cache-http-public-key",  config.getCacheHttpPubKey());

--- a/android/ouinet/src/test/java/ie/equalit/ouinet/ConfigTest.java
+++ b/android/ouinet/src/test/java/ie/equalit/ouinet/ConfigTest.java
@@ -43,6 +43,9 @@ public class ConfigTest {
     private static String CACHE_STATIC_CONTENT_PATH = "static-cache/.ouinet";
     private static String LISTEN_ON_TCP = "0.0.0.0:8077";
     private static String FRONT_END_EP = "0.0.0.0:8078";
+    private static String MAX_CACHED_AGE = "120";
+    private static String LOCAL_DOMAIN = "local.domain";
+    private static String ORIGIN_DOH_BASE = "0.0.0.0:8079";
 
     static {
         BT_BOOTSTRAP_EXTRAS.add("192.0.2.1");
@@ -94,6 +97,9 @@ public class ConfigTest {
                 .setCacheStaticContentPath(cacheStaticContentPath)
                 .setListenOnTcp(LISTEN_ON_TCP)
                 .setFrontEndEp(FRONT_END_EP)
+                .setMaxCachedAge(MAX_CACHED_AGE)
+                .setLocalDomain(LOCAL_DOMAIN)
+                .setOriginDohBase(ORIGIN_DOH_BASE)
                 .build();
 
         assertThat(config.getOuinetDirectory(), is(ouinetDir));
@@ -107,6 +113,9 @@ public class ConfigTest {
 
         assertThat(config.getListenOnTcp(), is(LISTEN_ON_TCP));
         assertThat(config.getFrontEndEp(), is(FRONT_END_EP));
+        assertThat(config.getMaxCachedAge(), is(MAX_CACHED_AGE));
+        assertThat(config.getLocalDomain(), is(LOCAL_DOMAIN));
+        assertThat(config.getOriginDohBase(), is(ORIGIN_DOH_BASE));
 
         assertThat(config.getTlsCaCertStorePath(), is(tlsCaCertPath));
         assertThat(contentOf(new File(config.getTlsCaCertStorePath())), is(TLS_CA_CERT));


### PR DESCRIPTION
Hello, this is the branch that exposes max-cached-age, local-domain and origin-doh-base options in Ouinet.java

For the testing I've added some assertions to ConfigTest and also modified ouinet-examples in a [commit](https://github.com/dem31/ouinet-examples/commit/cdc8d79a4d75e3dea09a4d3cc94b869c324b70d5)  to merge afterwards with committed ouinet lib update.

I've changed the code as follows:

`Config config = new Config.ConfigBuilder(this)`
        ` // ...`
        ` .setMaxCachedAge("-1") //never discard cache`
        ` .setLocalDomain("localhost")`
         `.setOriginDohBase("8.8.8.8")`