### PR TITLE
Fix memroy leak from unused broadcast receivers

### DIFF
--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -167,7 +167,8 @@ public class Ouinet {
 
         nStartClient(args.toArray(new String[0]), path.toArray(new String[0]));
 
-        registerBroadcastReceivers();
+        // Remove receivers, they were unused and causing memory leaks
+        //registerBroadcastReceivers();
     }
 
     // If this succeeds, we should be able to do UDP multicasts
@@ -195,25 +196,17 @@ public class Ouinet {
     // ouinet/client will have all of it's resources freed. It should be called
     // no later than in Activity.onDestroy()
     public synchronized void stop() {
-        if (Build.VERSION.SDK_INT >= 31) {
-            if (getState() == RunningState.Stopped) return;
-        }
+        if (getState() == RunningState.Stopped) return;
 
         nStopClient();
 
-        // Earlier versions of Android might not set lock isHeld,
-        // Avoid memory leak caused by failing to unregister the receivers
-        if (Build.VERSION.SDK_INT >= 31) {
-            if (lock != null && lock.isHeld()) {
-                lock.release();
-            }
-        }
-        else {
-            if (lock != null) {
-                lock.release();
-            }
+        if (lock != null && lock.isHeld()) {
+            lock.release();
         }
 
+        /*
+        // Remove receivers, they were unused and causing memory leaks,
+        // changes in network connectivity or charging status should be handled by the application
         if (wifiChangeReceiver != null) {
             context.unregisterReceiver(wifiChangeReceiver);
             wifiChangeReceiver = null;
@@ -222,6 +215,7 @@ public class Ouinet {
             context.unregisterReceiver(chargingChangeReceiver);
             chargingChangeReceiver = null;
         }
+        */
     }
 
     private void registerBroadcastReceivers() {

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -195,12 +195,25 @@ public class Ouinet {
     // ouinet/client will have all of it's resources freed. It should be called
     // no later than in Activity.onDestroy()
     public synchronized void stop() {
-        if (getState() == RunningState.Stopped) return;
+        if (Build.VERSION.SDK_INT >= 31) {
+            if (getState() == RunningState.Stopped) return;
+        }
 
         nStopClient();
-        if (lock != null && lock.isHeld()) {
-            lock.release();
+
+        // Earlier versions of Android might not set lock isHeld,
+        // Avoid memory leak caused by failing to unregister the receivers
+        if (Build.VERSION.SDK_INT >= 31) {
+            if (lock != null && lock.isHeld()) {
+                lock.release();
+            }
         }
+        else {
+            if (lock != null) {
+                lock.release();
+            }
+        }
+
         if (wifiChangeReceiver != null) {
             context.unregisterReceiver(wifiChangeReceiver);
             wifiChangeReceiver = null;


### PR DESCRIPTION
This merge request fixes a bug in the v0.21.3 ouinet AAR in which broadcast receivers were not being unregistered, resulting in a memory leak and possible notification that the app using ouinet (i.e. CENO) has a problem (e.g. it has stopped or needs to have its cache cleared). 

The simple solution was to remove the registering and unregistering of these receivers. Looking at [these lines](https://github.com/equalitie/ouinet/blob/master/src/client.cpp#L2859-L2867) in client.cpp, the usage of these receivers was never implemented, so it is very safe to remove them.