### PR TITLE
Fix thread join

### DIFF
--- a/android/ouinet/src/main/cpp/native-lib.cpp
+++ b/android/ouinet/src/main/cpp/native-lib.cpp
@@ -176,6 +176,7 @@ Java_ie_equalit_ouinet_Ouinet_nStopClient(
         jobject /* this */)
 {
     try {
+      if (g_client_thread.get_id() == thread::id()) return;
       g_ios.post([] { if (g_client) g_client->stop(); });
       g_client_thread.join();
       g_client_thread = thread();

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -167,8 +167,7 @@ public class Ouinet {
 
         nStartClient(args.toArray(new String[0]), path.toArray(new String[0]));
 
-        // Remove receivers, they were unused and causing memory leaks
-        //registerBroadcastReceivers();
+        registerBroadcastReceivers();
     }
 
     // If this succeeds, we should be able to do UDP multicasts
@@ -199,14 +198,9 @@ public class Ouinet {
         if (getState() == RunningState.Stopped) return;
 
         nStopClient();
-
         if (lock != null && lock.isHeld()) {
             lock.release();
         }
-
-        /*
-        // Remove receivers, they were unused and causing memory leaks,
-        // changes in network connectivity or charging status should be handled by the application
         if (wifiChangeReceiver != null) {
             context.unregisterReceiver(wifiChangeReceiver);
             wifiChangeReceiver = null;
@@ -215,7 +209,6 @@ public class Ouinet {
             context.unregisterReceiver(chargingChangeReceiver);
             chargingChangeReceiver = null;
         }
-        */
     }
 
     private void registerBroadcastReceivers() {

--- a/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
+++ b/android/ouinet/src/main/java/ie/equalit/ouinet/Ouinet.java
@@ -195,8 +195,6 @@ public class Ouinet {
     // ouinet/client will have all of it's resources freed. It should be called
     // no later than in Activity.onDestroy()
     public synchronized void stop() {
-        if (getState() == RunningState.Stopped) return;
-
         nStopClient();
         if (lock != null && lock.isHeld()) {
             lock.release();


### PR DESCRIPTION
This PR  partially reverts the fixes made in ouinet v0.21.3 for the error `thread::join failed: Invalid argument`, instead of relying on the getState function, which isn't synchronized, it checks that the g_client_thread.get_id method does not return the default thread id (i.e. it has been initialized and is, therefore, able to have it's stop method called.  

Additionally, it completely reverts the fix applied in v0.21.4 which attempted to avoid issues registering and unregistering broadcast receivers by simply removing them. Instead, this error indicates a problem in the application  (e.g. CENO) with how it is starting and stopping the ouinet client. I've added the receivers back to the ouinet code (even though they are essentially unused) and will apply a fix in CENO. 

Both of these changes were suggested by @inetic  and should be reviewed. 